### PR TITLE
Minor correction to tests and coverage to ensure tests passing, removes DeepBench as a dep

### DIFF
--- a/src/deepdiagnostics/metrics/coverage_fraction.py
+++ b/src/deepdiagnostics/metrics/coverage_fraction.py
@@ -101,8 +101,8 @@ class CoverageFraction(Metric):
         coverage_std = np.std(count_array, axis=0)
 
         self.output = {
-            "coverage": coverage_mean,
-            "coverage_std": coverage_std,
+            "coverage": coverage_mean.tolist(),
+            "coverage_std": coverage_std.tolist(),
 
         }
 

--- a/src/deepdiagnostics/metrics/local_two_sample.py
+++ b/src/deepdiagnostics/metrics/local_two_sample.py
@@ -72,7 +72,7 @@ class LocalTwoSampleTest(Metric):
                 sim_out_shape = (sim_out_shape[1], sim_out_shape[2])
                 remove_first_dim = True
 
-            sim_out_shape = np.product(sim_out_shape)
+            sim_out_shape = np.prod(sim_out_shape)
             self.outcome_given_p = np.zeros((self.number_simulations, sim_out_shape))
         else: 
             raise NotImplementedError("LC2ST only implemented for 1 or two dimensions.")
@@ -175,7 +175,7 @@ class LocalTwoSampleTest(Metric):
                 sim_out_shape = (sim_out_shape[1], sim_out_shape[2])
                 remove_first_dim = True
 
-            sim_out_shape = np.product(sim_out_shape)
+            sim_out_shape = np.prod(sim_out_shape)
             self.evaluation_data = np.zeros((n_cross_folds, len(next(cv_splits)[1]), sim_out_shape))
         
         self.prior_evaluation = np.zeros_like(p)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -44,30 +44,23 @@ class MockSimulator(Simulator):
 
 class Mock2DSimulator(Simulator): 
     def __init__(self) -> None:
-        import subprocess
-        subprocess.check_call(["python3", "-m", "pip", "install", "deepbench"])
+        "Create a 2D simulator that just produces noise"
 
     def generate_context(self, n_samples: int) -> np.ndarray: 
         return np.linspace(0, 28, n_samples)
 
     def simulate(self, theta, context_samples: np.ndarray): 
-        from deepbench.astro_object import StarObject
 
         generated_stars = []
         if len(theta.shape) == 1: 
             theta = [theta]
             
         for sample_index, t in enumerate(theta): 
-            star = StarObject(
-                image_dimensions = (28,28),
-                noise_level = 0.3,
-                radius = t[0].item(),
-                amplitude = t[1].item()
+            mock_data = np.random.normal(
+                loc=t[0], scale=abs(t[1]), size=(len(context_samples), 2)
             )
             generated_stars.append(
-                star.create_object(
-                    context_samples[sample_index].item(), context_samples[sample_index].item()
-                )
+                np.column_stack((context_samples, mock_data))
             )
         return np.array(generated_stars)
 
@@ -82,8 +75,7 @@ def setUp(result_output):
     sim_paths = f"{simulator_config_path.strip('/')}/simulators.json"
     os.remove(sim_paths)
 
-    out_dir = get_item("common", "out_dir", raise_exception=True)
-    shutil.rmtree(out_dir)
+    shutil.rmtree(result_output, ignore_errors=True)
 
 @pytest.fixture
 def model_path():

--- a/tests/test_metrics.py
+++ b/tests/test_metrics.py
@@ -20,10 +20,11 @@ def metric_config(config_factory):
 def test_coverage_fraction(metric_config, mock_model, mock_data, mock_run_id): 
     Config(metric_config)
     coverage_fraction = CoverageFraction(mock_model, mock_data, mock_run_id, save=True)
-    _, coverage = coverage_fraction.calculate()
-    assert coverage_fraction.output.all() is not None
+    _, (coverage_mean, coverage_std) = coverage_fraction.calculate()
+    assert coverage_mean.all() is not None
+    assert coverage_std.all() is not None
 
-    assert coverage.shape  ==  (1, 2) # One percentile over 2 dimensions of theta. 
+    assert coverage_mean.shape  ==  (1, 2) # One percentile over 2 dimensions of theta. 
 
     coverage_fraction = CoverageFraction(mock_model, mock_data, mock_run_id, save=True)
     coverage_fraction()


### PR DESCRIPTION
* Deepbench still works just fine, but the install util here complains about it being installed within the tests
* Some outdated behavior in the metrics::test_coverage 
* Use of "np.product" instead of "np.prod" in l2cst - not sure how that got this far